### PR TITLE
Cambios en la función searchTracks

### DIFF
--- a/lib/goear_api.js
+++ b/lib/goear_api.js
@@ -58,7 +58,7 @@ exports.search = function(searchTerm, options, callback) {
 
 	// We issue a first request to test if there are any result and
 	// to get the total number
-	service.searchTracks(searchTerm, 0, function(err, data) {
+	return service.searchTracks(searchTerm, 0, function(err, data) {
 
 		if (err) {
 			callback(err);
@@ -87,8 +87,11 @@ exports.search = function(searchTerm, options, callback) {
 					},
 					function(innerCallback) {
 						service.searchTracks(searchTerm, counter++, function(err, innerData) {
-							totalCount = innerData.totalCount;
-							tracks = tracks.concat(filterTracks(innerData.tracks, options.minQuality));
+
+							if(innerData){
+								totalCount = innerData.totalCount;
+								tracks = tracks.concat(filterTracks(innerData.tracks, options.minQuality));
+							}
 							// util.log("New tracks quantity: " + filterTracks(innerData.tracks, options.minQuality).length);
 							innerCallback(err);
 						});

--- a/lib/service.js
+++ b/lib/service.js
@@ -70,7 +70,12 @@ exports.searchTracks = function(searchTerm, offset, callback) {
 	}));
 	// util.log("--> Search URL: " + searchUrl);
 
-	request(searchUrl, function(error, response, body) {
+	return request({
+		uri: searchUrl,
+		headers:{
+			"User-Agent":"Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.101 Safari/537.36"
+		}
+	}, function(error, response, body) {
 		if (error) {
 			callback(error);
 		} else if (response.statusCode !== 200) {
@@ -93,13 +98,16 @@ exports.searchTracks = function(searchTerm, offset, callback) {
 			if (result.totalCount > 0) {
 				$('.results_list > li').each(function(index, item) {
 					searchResult = $(this);
-					trackId = searchResult.find('.title a').attr('href').match(/listen\/(.*)\//)[1];
+					var href= searchResult.find('.title a').attr('href');
+					trackId = href.match(/listen\/(.*)\//)[1];
 					result.tracks.push({
 						id: trackId,
+						href: href,
 						title: searchResult.find('.title').text(),
 						artist: searchResult.find('.band').text(),
 						quality: parseInt(searchResult.find('.kbps').text().trim(), 10),
 						duration: searchResult.find('.length').text().trim(),
+						picture: searchResult.find('.cover').attr("src"),
 						link: serviceConfig.trackLinkBaseUrl.replace('{trackId}', trackId)
 					});
 				});


### PR DESCRIPTION
Buenas tardes, 

Los cambios hechos en el proyecto son pocos. 
Permitir cancelar la búsqueda, devolviendo en la función searchTracks un objeto 'request'
Solucionar error en el callback de service.searchTracks cuando no se obtenía información de la búsqueda salía error de operación sobre null
Se modificó service.searchTracks para que en los resultados cada objeto 'track' tenga también las siguientes propiedades: picture, href
